### PR TITLE
Atualiza a imagem hello-app para a versão 17

### DIFF
--- a/manifests/deploy.yaml
+++ b/manifests/deploy.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: hello-app-container
-        image: gelleres/hello-app:16
+        image: gelleres/hello-app:17
         ports:
         - containerPort: 80
 ---


### PR DESCRIPTION
Este PR atualiza a tag da imagem `hello-app` para a versão mais recente do build do CI/CD.